### PR TITLE
add-topic-to-event-header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <guava.version>18.0</guava.version>
     <flume.version>1.5.2</flume.version>
-    <rocketmq.version>3.2.2</rocketmq.version>
+    <rocketmq.version>3.2.6</rocketmq.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.9.0</mockito.version>
   </properties>
@@ -77,6 +77,17 @@
 
   <build>
     <defaultGoal>clean install dependency:copy-dependencies</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSource.java
+++ b/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSource.java
@@ -51,6 +51,8 @@ public class RocketMQSource extends AbstractSource implements Configurable, Poll
 
     private String topic;
     private String tags;
+    private String topicHeaderName;
+    private String tagsHeaderName;
     private int maxNums;
     private MQPullConsumer consumer;
 
@@ -59,6 +61,8 @@ public class RocketMQSource extends AbstractSource implements Configurable, Poll
         // 初始化配置项
         topic = Preconditions.checkNotNull(context.getString(RocketMQSourceUtil.TOPIC_CONFIG), "RocketMQ topic must be specified. For example: a1.sources.r1.topic=TestTopic");
         tags = context.getString(RocketMQSourceUtil.TAGS_CONFIG, RocketMQSourceUtil.TAGS_DEFAULT);
+        topicHeaderName = context.getString(RocketMQSourceUtil.TOPIC_HEADER_NAME_CONFIG, RocketMQSourceUtil.TOPIC_HEADER_NAME_DEFAULT);
+        tagsHeaderName = context.getString(RocketMQSourceUtil.TAGS_HEADER_NAME_CONFIG, RocketMQSourceUtil.TAGS_HEADER_NAME_DEFAULT);
         maxNums = context.getInteger(RocketMQSourceUtil.MAXNUMS_CONFIG, RocketMQSourceUtil.MAXNUMS_DEFAULT);
 
         // 初始化Consumer
@@ -81,8 +85,11 @@ public class RocketMQSource extends AbstractSource implements Configurable, Poll
                     for (MessageExt messageExt : pullResult.getMsgFoundList()) {
                         event = new SimpleEvent();
                         headers = new HashMap<String, String>();
+                        headers.put(topicHeaderName, messageExt.getTopic());
+                        headers.put(tagsHeaderName, messageExt.getTags());
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("MessageQueue={}, Message: {}", mq, messageExt.getBody());
+                            LOG.debug("MessageQueue={}, Topic={}, Tags={}, Message: {}",new Object[] {
+                                    mq, messageExt.getTopic(), messageExt.getTags(), messageExt.getBody()});
                         }
                         event.setBody(messageExt.getBody());
                         event.setHeaders(headers);

--- a/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSourceUtil.java
+++ b/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSourceUtil.java
@@ -39,6 +39,16 @@ public class RocketMQSourceUtil {
     public static final String TAGS_CONFIG = "tags";
     public static final String TAGS_DEFAULT = "*";
     /**
+     * Tags header name configuration, eg: a1.sources.r1.tagsHeaderName=name
+     */
+    public static final String TAGS_HEADER_NAME_CONFIG = "tagsHeaderName";
+    public static final String TAGS_HEADER_NAME_DEFAULT = "tags";
+    /**
+     * Topic header name configuration, eg: a1.sources.r1.tagsHeaderName=name
+     */
+    public static final String TOPIC_HEADER_NAME_CONFIG = "topicHeaderName";
+    public static final String TOPIC_HEADER_NAME_DEFAULT = "topic";
+    /**
      * 一次最多拉取条数配置项，如：a1.sources.r1.maxNums=150
      */
     public static final String MAXNUMS_CONFIG = "maxNums";

--- a/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSourceUtil.java
+++ b/rocketmq-flume-source/src/main/java/com/handu/flume/source/rocketmq/RocketMQSourceUtil.java
@@ -44,7 +44,7 @@ public class RocketMQSourceUtil {
     public static final String TAGS_HEADER_NAME_CONFIG = "tagsHeaderName";
     public static final String TAGS_HEADER_NAME_DEFAULT = "tags";
     /**
-     * Topic header name configuration, eg: a1.sources.r1.tagsHeaderName=name
+     * Topic header name configuration, eg: a1.sources.r1.topicHeaderName=name
      */
     public static final String TOPIC_HEADER_NAME_CONFIG = "topicHeaderName";
     public static final String TOPIC_HEADER_NAME_DEFAULT = "topic";


### PR DESCRIPTION
1. 把topic和tags加入到event header里去，这样flume这边可以根据上述信息决定如何处理相应的消息。
2. 调整了pom里面的rocketmq依赖，先前的版本现在maven资源库里拿不到。
3. 加入了compiler level的指定，这样直接导入IDE如IntelliJ不会报错。